### PR TITLE
Migrate transaction types to a database enum instead of using a separate table

### DIFF
--- a/supabase/migrations/20231008201517_enum_transaction_types.sql
+++ b/supabase/migrations/20231008201517_enum_transaction_types.sql
@@ -1,0 +1,8 @@
+create type transaction_type as enum ('balance', 'expense');
+
+alter table if exists transactions
+    add column if not exists transaction_type transaction_type not null,
+    drop constraint if exists fk_transaction_type,
+    drop column if exists transaction_type_id;
+
+drop table if exists transaction_types;

--- a/supabase/seed.sql
+++ b/supabase/seed.sql
@@ -1,8 +1,3 @@
--- seed transaction_types table
-insert into transaction_types (name) values
-    ('Balance'),
-    ('Expense');
-
 -- seed categories table
 insert into categories (name) values
     ('Food'),


### PR DESCRIPTION
### Changes

- Add new `transaction_type` enum
- Add `transaction_type` column to `transactions` table
- Drop `transaction_type_id` from `transactions` table
- Drop `transaction_types` table
- Remove initial transaction types data from seed file

### Schema

https://www.figma.com/file/VpeN2TY4jfLY3Zh987h6YR/Money-App?type=whiteboard&node-id=0%3A1&t=i0ww77Cqy2LhfGnT-1